### PR TITLE
Update URLs to use HTTPS

### DIFF
--- a/site/src/site/settings.mkd
+++ b/site/src/site/settings.mkd
@@ -55,9 +55,9 @@ The default *readTimeout* is 1800 seconds (30 mins).
 
 ---YAML---
 registeredRepositories:
-- { id: 'central', url: 'http://repo1.maven.org/maven2' }
-- { id: 'mavencentral', url: 'http://repo1.maven.org/maven2' }
 - { id: 'codehaus', url: 'http://repository.codehaus.org' }
+- { id: 'central', url: 'https://repo1.maven.org/maven2' }
+- { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {
     id: 'sonatype-oss'
     url: 'https://oss.sonatype.org/content/groups/public'
@@ -67,7 +67,7 @@ registeredRepositories:
   }
 - {
     id: 'restlet'
-    url: 'http://maven.restlet.org'
+    url: 'https://maven.restlet.org'
     # Snapshot Purge Policy
     revisionRetentionCount: 1
     revisionPurgeAfterDays: 0

--- a/site/src/site/settings.mkd
+++ b/site/src/site/settings.mkd
@@ -55,7 +55,6 @@ The default *readTimeout* is 1800 seconds (30 mins).
 
 ---YAML---
 registeredRepositories:
-- { id: 'codehaus', url: 'http://repository.codehaus.org' }
 - { id: 'central', url: 'https://repo1.maven.org/maven2' }
 - { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {

--- a/toolkit/src/all/resources/maven/index.html
+++ b/toolkit/src/all/resources/maven/index.html
@@ -9,7 +9,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.5/angular.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.5/angular-resource.min.js"></script>
-    <script src="http://angular-ui.github.com/bootstrap/ui-bootstrap-tpls-0.2.0.js"></script>
+    <script src="https://angular-ui.github.io/bootstrap/ui-bootstrap-tpls-0.2.0.js"></script>
     <!--<script src="https://google-code-prettify.googlecode.com/svn/loader/prettify.js"></script>-->
     <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <style type="text/css">

--- a/toolkit/src/core/java/org/moxie/ToolkitConfig.java
+++ b/toolkit/src/core/java/org/moxie/ToolkitConfig.java
@@ -103,7 +103,7 @@ public class ToolkitConfig implements Serializable {
 		targetDirectory = new File("build/target");
 		linkedModules = new ArrayList<Module>();
 		repositories = Arrays.asList("central");
-		registeredRepositories = Arrays.asList(new RemoteRepository("central", "http://repo1.maven.org/maven2", false));
+		registeredRepositories = Arrays.asList(new RemoteRepository("central", "https://repo1.maven.org/maven2/", false));
 		pom = new Pom();
 		dependencyDirectory = null;
 		dependencyNamePattern = Toolkit.DEPENDENCY_FILENAME_PATTERN;

--- a/toolkit/src/core/resources/settings.moxie
+++ b/toolkit/src/core/resources/settings.moxie
@@ -16,7 +16,6 @@ proxies:
 # a complete url.  A repository definition can override the default snapshot
 # revision purge policy.
 registeredRepositories:
-- { id: 'codehaus', url: 'http://repository.codehaus.org' }
 - { id: 'central', url: 'https://repo1.maven.org/maven2' }
 - { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {

--- a/toolkit/src/core/resources/settings.moxie
+++ b/toolkit/src/core/resources/settings.moxie
@@ -16,9 +16,9 @@ proxies:
 # a complete url.  A repository definition can override the default snapshot
 # revision purge policy.
 registeredRepositories:
-- { id: 'central', url: 'http://repo1.maven.org/maven2' }
-- { id: 'mavencentral', url: 'http://repo1.maven.org/maven2' }
 - { id: 'codehaus', url: 'http://repository.codehaus.org' }
+- { id: 'central', url: 'https://repo1.maven.org/maven2' }
+- { id: 'mavencentral', url: 'https://repo1.maven.org/maven2' }
 - {
     id: 'sonatype-oss'
     url: 'https://oss.sonatype.org/content/groups/public'
@@ -27,7 +27,7 @@ registeredRepositories:
   }
 - {
     id: 'restlet'
-    url: 'http://maven.restlet.org'
+    url: 'https://maven.restlet.org'
     revisionRetentionCount: 1
     revisionPurgeAfterDays: 0
     # define a groupid affinity for all org.restlet artifacts


### PR DESCRIPTION
Since January 2020, Maven Central has stopped accepting the http
transport. 
This pull request updates URLs to the built-in default registeredRepositories
to use https. 

As well, it updates the link to Angular-UI to use https, so that the constructed
Maven repository will work via https.

Remove the Codehaus maven repository from registeredRepositories.